### PR TITLE
Fix all.yml to not run into race condition on package install

### DIFF
--- a/all.yml
+++ b/all.yml
@@ -2,7 +2,7 @@
 # Update the DB download link and checksum in the host_vars first!
 ---
 - name: setup
-  hosts: all
+  hosts: polkadot
   become: yes
   roles:
   - polkadot-setup


### PR DESCRIPTION
Before triggering the `ansible-playbook -i hosts.ini all.yml` the user would run into a race condition where it tries to install the packages on the same server in parallel. Limit to polkadot host only.