### PR TITLE
Fix validator mount-point

### DIFF
--- a/roles/polkadot-validator/tasks/validator.yml
+++ b/roles/polkadot-validator/tasks/validator.yml
@@ -40,7 +40,7 @@
                         "--telemetry-url={{ telemetry_url }} 1"
                     ]
                 volumes:
-                - "{{ db_path }}:/polkadot"
+                - "{{ db_path }}:/parity"
                 ports:
                 - "{{ rpc_listen }}:9933"
                 - "{{ ws_listen }}:9944"


### PR DESCRIPTION
This fixes the FUCKUP of parity by having the database mounted at /parity instead of /polkadot